### PR TITLE
Rename to typedecl

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,7 @@ formatters:
   settings:
     goimports:
       local-prefixes:
-        - github.com/gaqzi/enums
+        - github.com/gaqzi/typedecl
   exclusions:
     generated: lax
     paths:

--- a/README.md
+++ b/README.md
@@ -1,22 +1,23 @@
-enums
+typedecl
 =====
 
-[![godocs.io](http://godocs.io/github.com/gaqzi/enums?status.svg)](http://godocs.io/github.com/gaqzi/enums)
+[![godocs.io](http://godocs.io/github.com/gaqzi/typedecl.svg)](http://godocs.io/github.com/gaqzi/typedecl)?status.svg)](http://godocs.io/github.com/gaqzi/typedecl)
 
 Uses the AST to find all variables of a certain type in a package. 
 This is useful for cases where you need to ensure that all values 
 of a type is accounted for somewhere. There is an overlap with the
 [exhaustive] project which does this for `switch` statements.
 
-[exhaustive]: https://github.com/nishanths/exhaustive
+This package finds all top-level declarations of a named type that are
+[basic literals] (strings, numbers) and structs,
+so that you can perform logic on all of those declared values.
 
-For the sake of this package an `enum` is a named type with multiple
-values which you're operating on as a collection. Enums supports what Go 
-refers to as basic literals (strings, numbers) and structs.
+[exhaustive]: https://github.com/nishanths/exhaustive
+[basic literals]: https://go.dev/ref/spec#Operands
 
 ## Example
 
-For example, I have an enum type for feature flags. For each request
+For example, I have a type for feature flags. For each request
 I call a 3rdparty service to check the state of each flag, so whenever
 a new flag is created it needs to be added to the `AllFlags` function.
 
@@ -36,11 +37,11 @@ func AllFlags() []Flag {
 }
 ```
 
-Using enums we can test that we haven't missed out on a new flag:
+Using `typedecl` we can test that we haven't missed out on a new flag:
 
 ```golang
 func TestAllFlagsCovered(t *testing.T) {
-    enumstest.NoDiff(t, "./feature", "feature.Flag", full.AllFlags())
+    typedecltest.NoDiff(t, "./feature", "feature.Flag", full.AllFlags())
 }
 ```
 
@@ -48,11 +49,11 @@ func TestAllFlagsCovered(t *testing.T) {
 
 We need a way to uniquely identify values in a struct, so the identifier 
 will still have to be a basic literal, and this is done with the 
-`enums:"identifier"` tag.
+`typedecl:"identifier"` tag.
 
 ```golang
 type DefaultFlag struct {
-    Name string `enums:"identifier"`
+    Name string `typedecl:"identifier"`
     IsOn bool
 }
 ```

--- a/example_test.go
+++ b/example_test.go
@@ -1,4 +1,4 @@
-package enums_test
+package typedecl_test
 
 import (
 	"testing"
@@ -6,18 +6,18 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/gaqzi/enums"
-	"github.com/gaqzi/enums/enumstest"
-	"github.com/gaqzi/enums/testdata/full"
+	"github.com/gaqzi/typedecl"
+	"github.com/gaqzi/typedecl/testdata/full"
+	"github.com/gaqzi/typedecl/typedecltest"
 )
 
 func TestIntegration(t *testing.T) {
-	collection, err := enums.All("./testdata/full", "full.Flag")
+	collection, err := typedecl.All("./testdata/full", "full.Flag")
 	require.NoError(t, err)
 
 	t.Run("No error when no difference", func(t *testing.T) {
 		// Using the helper for the most common scenario
-		enumstest.NoDiff(
+		typedecltest.NoDiff(
 			t,
 			"./testdata/full",
 			"full.Flag",
@@ -28,14 +28,14 @@ func TestIntegration(t *testing.T) {
 
 	t.Run("Indicates a difference when one is set", func(t *testing.T) {
 		// If you need more control over which flags are part of the
-		// lookup you can modify the returned `enums.Diff` object.
+		// lookup you can modify the returned `typedecl.Diff` object.
 		diff := collection.Diff(full.MissingFlags())
 
 		assert.False(t, diff.Zero(), "expected to have indicated a diff: %s", diff)
 	})
 
-	t.Run("Handles structs as enum type", func(t *testing.T) {
-		fsCollection, err := enums.All("./testdata/full", "full.FlagStruct")
+	t.Run("Handles structs", func(t *testing.T) {
+		fsCollection, err := typedecl.All("./testdata/full", "full.FlagStruct")
 		require.NoError(t, err)
 
 		t.Run("when all flags are present", func(t *testing.T) {
@@ -50,11 +50,11 @@ func TestIntegration(t *testing.T) {
 		t.Run("when something is missing", func(t *testing.T) {
 			require.Equal(
 				t,
-				enums.Diff{
-					Missing: enums.Collection{
-						Type:      "github.com/gaqzi/enums/testdata/full.FlagStruct",
+				typedecl.Diff{
+					Missing: typedecl.Collection{
+						Type:      "github.com/gaqzi/typedecl/testdata/full.FlagStruct",
 						FieldName: "Name",
-						Enums: []enums.Enum{
+						Matches: []typedecl.Match{
 							{"FlagDefaultOn", `"flag-default-on"`},
 						},
 					},

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gaqzi/enums
+module github.com/gaqzi/typedecl
 
 go 1.23
 

--- a/testdata/full/example_struct.go
+++ b/testdata/full/example_struct.go
@@ -1,7 +1,7 @@
 package full
 
 type FlagStruct struct {
-	Name      string `enums:"identifier"`
+	Name      string `typedecl:"identifier"`
 	DefaultOn bool
 }
 

--- a/typedecl_test.go
+++ b/typedecl_test.go
@@ -1,4 +1,4 @@
-package enums_test
+package typedecl_test
 
 import (
 	"fmt"
@@ -7,26 +7,26 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/gaqzi/enums"
+	"github.com/gaqzi/typedecl"
 )
 
 func TestAll(t *testing.T) {
 	t.Run("returns an empty collection when no matches found", func(t *testing.T) {
-		matches, err := enums.All("./testdata/nomatch", "Flag")
+		matches, err := typedecl.All("./testdata/nomatch", "Flag")
 		require.NoError(t, err, "error when scanning testdata/nomatches")
 
 		require.Empty(t, matches, "expected to not have found any matches")
 	})
 
 	t.Run("when one match found return it", func(t *testing.T) {
-		matches, err := enums.All("./testdata/singlematch", "singlematch.Flag")
+		matches, err := typedecl.All("./testdata/singlematch", "singlematch.Flag")
 		require.NoError(t, err, "error when scanning testdata/singlematch")
 
 		require.Equal(
 			t,
-			enums.Collection{
-				Type: "github.com/gaqzi/enums/testdata/singlematch.Flag",
-				Enums: []enums.Enum{
+			typedecl.Collection{
+				Type: "github.com/gaqzi/typedecl/testdata/singlematch.Flag",
+				Matches: []typedecl.Match{
 					{
 						Name:  "FlagSomethingCouldBe",
 						Value: `"flag-whatever"`,
@@ -39,14 +39,14 @@ func TestAll(t *testing.T) {
 	})
 
 	t.Run("returns all matches found", func(t *testing.T) {
-		matches, err := enums.All("./testdata/multimatch", "multimatch.Flag")
+		matches, err := typedecl.All("./testdata/multimatch", "multimatch.Flag")
 		require.NoError(t, err, "error when scanning testdata/multimatch")
 
 		require.Equal(
 			t,
-			enums.Collection{
-				Type: "github.com/gaqzi/enums/testdata/multimatch.Flag",
-				Enums: []enums.Enum{
+			typedecl.Collection{
+				Type: "github.com/gaqzi/typedecl/testdata/multimatch.Flag",
+				Matches: []typedecl.Match{
 					{
 						Name:  "FlagSomethingCouldBe",
 						Value: `"flag-whatever"`,
@@ -63,15 +63,15 @@ func TestAll(t *testing.T) {
 	})
 
 	t.Run("does not match a variable declared in a func for the type", func(t *testing.T) {
-		// Fixes https://github.com/gaqzi/enums/issues/38.
-		matches, err := enums.All("./testdata/falsepositiveinfunc", "Flag")
+		// Fixes https://github.com/gaqzi/typedecl/issues/38.
+		matches, err := typedecl.All("./testdata/falsepositiveinfunc", "Flag")
 		require.NoError(t, err, "error when scanning testdata/falsepositiveinfunc")
 
 		require.Equal(
 			t,
-			enums.Collection{
-				Type: "github.com/gaqzi/enums/testdata/falsepositiveinfunc.Flag",
-				Enums: []enums.Enum{
+			typedecl.Collection{
+				Type: "github.com/gaqzi/typedecl/testdata/falsepositiveinfunc.Flag",
+				Matches: []typedecl.Match{
 					{
 						Name:  "AnotherExample",
 						Value: `"hello-there"`,
@@ -98,10 +98,10 @@ func TestCollection_Diff(t *testing.T) {
 	t.Run("Same values returns an empty string", func(t *testing.T) {
 		require.Equal(
 			t,
-			enums.Diff{Missing: enums.Collection{Type: "enums_test.val"}},
-			enums.Collection{
-				Type: "enums_test.val",
-				Enums: []enums.Enum{
+			typedecl.Diff{Missing: typedecl.Collection{Type: "typedecl_test.val"}},
+			typedecl.Collection{
+				Type: "typedecl_test.val",
+				Matches: []typedecl.Match{
 					{"test", `"hello"`},
 				},
 			}.Diff([]val{test}),
@@ -112,17 +112,17 @@ func TestCollection_Diff(t *testing.T) {
 	t.Run("missing values are shown", func(t *testing.T) {
 		require.Equal(
 			t,
-			enums.Diff{
-				Missing: enums.Collection{
-					Type: "enums_test.val",
-					Enums: []enums.Enum{
+			typedecl.Diff{
+				Missing: typedecl.Collection{
+					Type: "typedecl_test.val",
+					Matches: []typedecl.Match{
 						{"test", `"hello"`},
 					},
 				},
 			},
-			enums.Collection{
-				Type: "enums_test.val",
-				Enums: []enums.Enum{
+			typedecl.Collection{
+				Type: "typedecl_test.val",
+				Matches: []typedecl.Match{
 					{"test", `"hello"`},
 				},
 			}.Diff([]val{}),
@@ -133,31 +133,31 @@ func TestCollection_Diff(t *testing.T) {
 	t.Run("extra values are shown", func(t *testing.T) {
 		require.Equal(
 			t,
-			enums.Diff{Extra: []string{`"m000"`}},
-			enums.Collection{}.Diff([]val{"m000"}),
+			typedecl.Diff{Extra: []string{`"m000"`}},
+			typedecl.Collection{}.Diff([]val{"m000"}),
 			"expected a diff message",
 		)
 	})
 
 	t.Run("handles structs", func(t *testing.T) {
 		type testStruct struct {
-			FieldA string `enums:"identifier"`
+			FieldA string `typedecl:"identifier"`
 		}
 		test := testStruct{FieldA: "Hello"}
-		collection := enums.Collection{
-			Type:      "enums_test.testStruct",
+		collection := typedecl.Collection{
+			Type:      "typedecl_test.testStruct",
 			FieldName: "FieldA",
-			Enums: []enums.Enum{
+			Matches: []typedecl.Match{
 				{"test", `"Hello"`},
 			},
 		}
 
-		t.Run("uses the first field that has `enum:\"identifier\"` as a tag", func(t *testing.T) {
+		t.Run("uses the first field that has `typedecl:\"identifier\"` as a tag", func(t *testing.T) {
 			require.Equal(
 				t,
-				enums.Diff{
-					Missing: enums.Collection{
-						Type:      "enums_test.testStruct",
+				typedecl.Diff{
+					Missing: typedecl.Collection{
+						Type:      "typedecl_test.testStruct",
 						FieldName: "FieldA",
 					},
 				},
@@ -168,13 +168,13 @@ func TestCollection_Diff(t *testing.T) {
 
 		t.Run("doesn't match fields for other struct types", func(t *testing.T) {
 			type otherStruct struct {
-				FieldA string `enums:"identifier"`
+				FieldA string `typedecl:"identifier"`
 			}
 			test := otherStruct{FieldA: "Hello"}
 
 			require.Equal(
 				t,
-				enums.Diff{
+				typedecl.Diff{
 					Extra:   []string{fmt.Sprintf("%#v", test)},
 					Missing: collection,
 				},
@@ -187,7 +187,7 @@ func TestCollection_Diff(t *testing.T) {
 
 func TestDiff(t *testing.T) {
 	t.Run("Handles all members of the struct", func(t *testing.T) {
-		typ := reflect.TypeOf(enums.Diff{})
+		typ := reflect.TypeOf(typedecl.Diff{})
 		var allFields []string
 
 		for i := 0; i < typ.NumField(); i++ {
@@ -204,34 +204,34 @@ func TestDiff(t *testing.T) {
 
 	testCases := []struct {
 		name     string
-		diff     enums.Diff
+		diff     typedecl.Diff
 		expected string
 		isZero   bool
 	}{
 		{
 			name:     "Diff is zero",
-			diff:     enums.Diff{},
+			diff:     typedecl.Diff{},
 			expected: "<Diff{}>",
 			isZero:   true,
 		},
 		{
 			name: "Missing is set",
-			diff: enums.Diff{Missing: enums.Collection{
+			diff: typedecl.Diff{Missing: typedecl.Collection{
 				Type: "full.Flag",
-				Enums: []enums.Enum{
+				Matches: []typedecl.Match{
 					{
 						Name:  "FlagSomething",
 						Value: "flag-something",
 					},
 				},
 			}},
-			expected: "Enums declared but not part of actual:\n" +
+			expected: "Matches declared but not part of actual:\n" +
 				"\tFlagSomething = flag-something\n",
 		},
 		{
 			name: "Extra is set",
-			diff: enums.Diff{Extra: []string{"hello"}},
-			expected: "Extra values provided but not part of Enums:\n" +
+			diff: typedecl.Diff{Extra: []string{"hello"}},
+			expected: "Extra values provided but not part of Matches:\n" +
 				"\thello\n",
 		},
 	}

--- a/typedecltest/helper.go
+++ b/typedecltest/helper.go
@@ -1,7 +1,7 @@
-package enumstest
+package typedecltest
 
 import (
-	"github.com/gaqzi/enums"
+	"github.com/gaqzi/typedecl"
 )
 
 type tHelper interface {
@@ -10,7 +10,7 @@ type tHelper interface {
 	Fail()
 }
 
-// NoDiff looks up all types in pkg and asserts they they have all the values from actual
+// NoDiff looks up all types in pkg and asserts they have all the values from actual.
 //
 // Example:
 //
@@ -18,9 +18,9 @@ type tHelper interface {
 func NoDiff(t tHelper, pkg, typ string, actual interface{}, failureMsg ...string) bool {
 	t.Helper()
 
-	collection, err := enums.All(pkg, typ)
+	collection, err := typedecl.All(pkg, typ)
 	if err != nil {
-		t.Log("failed to load enums.All: " + err.Error())
+		t.Log("failed to load typedecl.All: " + err.Error())
 		t.Fail()
 		return false
 	}

--- a/typedecltest/helper_test.go
+++ b/typedecltest/helper_test.go
@@ -1,12 +1,12 @@
-package enumstest_test
+package typedecltest_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/gaqzi/enums/enumstest"
-	"github.com/gaqzi/enums/testdata/full"
+	"github.com/gaqzi/typedecl/testdata/full"
+	"github.com/gaqzi/typedecl/typedecltest"
 )
 
 type tLogger struct {
@@ -31,7 +31,7 @@ func TestNoDiff(t *testing.T) {
 	t.Run("Does not call fail or log when there is no diff", func(t *testing.T) {
 		tl := new(tLogger)
 
-		require.True(t, enumstest.NoDiff(
+		require.True(t, typedecltest.NoDiff(
 			tl,
 			"../testdata/full",
 			"full.Flag",
@@ -50,7 +50,7 @@ func TestNoDiff(t *testing.T) {
 	t.Run("Fails the case when diffs are found", func(t *testing.T) {
 		tl := new(tLogger)
 
-		require.False(t, enumstest.NoDiff(
+		require.False(t, typedecltest.NoDiff(
 			tl,
 			"../testdata/full",
 			"full.Flag",
@@ -66,7 +66,7 @@ func TestNoDiff(t *testing.T) {
 				log: []interface{}{
 					[]interface{}{
 						"expected a missing difference\n" +
-							"Enums declared but not part of actual:\n" +
+							"Matches declared but not part of actual:\n" +
 							"\tDeployOneThing = \"deploy-one-thing\"\n",
 					},
 				},


### PR DESCRIPTION
I realized that enums had extra connotations than just "all the
enumerable values of this type" and that it lead to more confusion than
not. "typedecl" is very clearly about type declarations in a very Go
naming convention way, so it seems like a decent compromise towards
clarity as I'm preparing to tag v1.0. :)
